### PR TITLE
修复大模型返回 highlight.js 不支持的语言时对话框崩溃的问题

### DIFF
--- a/src/renderer/src/utils/markdown-util.ts
+++ b/src/renderer/src/utils/markdown-util.ts
@@ -25,7 +25,7 @@ clipboard.on('success', () => {
 // MarkdownIt
 const markdown = new MarkdownIt({
   highlight: (str: string, lang: string) => {
-    if (!lang) {
+    if (!lang || !hljs.getLanguage(lang)) {
       lang = 'text'
     }
     let codeHtml = `<code class="hljs language-${lang}">${


### PR DESCRIPTION
# 问题
大模型返回 highlight.js 不支持的语言类型时，对话框会崩溃。例如对 `deepseek` 提问 `在 ANTLR 中 -> skip 表示什么意思`，deepseek 会返回类型为 ANTLR 的语言，导致 highlight 渲染失败:
![AIHub 2025_2_6 20_10_12](https://github.com/user-attachments/assets/43740c08-81c3-42d6-8fde-2cc5f758400c)
```java
Error: Unknown language: "antlr"
    at _highlight (index-jbLkYdJ2.js:97101:13)
    at Object.highlight2 [as highlight] (index-jbLkYdJ2.js:96838:54)
    at Object.highlight (index-jbLkYdJ2.js:216571:72)
    at default_rules.fence (index-jbLkYdJ2.js:147279:28)
    at Renderer$1.render (index-jbLkYdJ2.js:147412:28)
    at MarkdownIt.render (index-jbLkYdJ2.js:151300:24)
    at renderMarkdown (index-jbLkYdJ2.js:216588:27)
    at index-jbLkYdJ2.js:225309:61
    at renderFnWithContext (index-jbLkYdJ2.js:1848:13)
    at renderSlot (index-jbLkYdJ2.js:3759:53)
````
# 解决方案
如果  highlight.js 中不存在该语言，则 fallback 到 text 渲染。
